### PR TITLE
Fix trailing comma in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'Topic :: Internet :: WWW/HTTP',
     ],
     install_requires=[
-        'prometheus-client>=0.0.20'
+        'prometheus-client>=0.0.20',
         'Scrapy>=1.4.0',
     ],
 )


### PR DESCRIPTION
There is a syntax error in `setup.py` which is preventing the module from installing properly in python poetry.
